### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Time/keywords.txt
+++ b/Time/keywords.txt
@@ -5,25 +5,25 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-time_t KEYWORD1
+time_t	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 now	KEYWORD2
-second KEYWORD2
+second	KEYWORD2
 minute	KEYWORD2
-hour KEYWORD2
-day KEYWORD2
-month KEYWORD2
-year KEYWORD2
-isAM KEYWORD2
-isPM KEYWORD2
-weekday KEYWORD2
-setTime KEYWORD2
-adjustTime KEYWORD2
-setSyncProvider KEYWORD2
-setSyncInteval KEYWORD2
-timeStatus KEYWORD2
+hour	KEYWORD2
+day	KEYWORD2
+month	KEYWORD2
+year	KEYWORD2
+isAM	KEYWORD2
+isPM	KEYWORD2
+weekday	KEYWORD2
+setTime	KEYWORD2
+adjustTime	KEYWORD2
+setSyncProvider	KEYWORD2
+setSyncInteval	KEYWORD2
+timeStatus	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords